### PR TITLE
Add predicates (>, <, =, etc.) to the query engine

### DIFF
--- a/src/unifydb/query.clj
+++ b/src/unifydb/query.clj
@@ -37,14 +37,16 @@
     (concat (qeval db (first disjuncts) rules frames)
             (disjoin db (rest disjuncts) rules frames))))
 
-;; This is a shitty implementation of negation because it acts only as a filter,
-;; meaning it is only valid as one of the subsequent clauses in an :and query.
-;; In other words, [:not [?e :name "Foo"]] always returns the empty stream, even if
-;; there are entities in the database whose :name is not "Foo". To get this to work
-;; right you'd need to do [:and [?e ?a ?v] [:not [?e :name "Foo"]]] - in other words,
-;; generating a stream of every fact in the database and then passing it through the
-;; :not filter. This is an acceptable solution for now but it should be clearly
-;; documented and hopefully one day improved.
+;; This is a shitty implementation of negation because it acts only as
+;; a filter, meaning it is only valid as one of the subsequent clauses
+;; in an :and query.  In other words, [:not [?e :name "Foo"]] always
+;; returns the empty stream, even if there are entities in the
+;; database whose :name is not "Foo". To get this to work right you'd
+;; need to do [:and [?e ?a ?v] [:not [?e :name "Foo"]]] - in other
+;; words, generating a stream of every fact in the database and then
+;; passing it through the :not filter. This is an acceptable solution
+;; for now but it should be clearly documented and hopefully one day
+;; improved.
 ;;
 ;; See also: https://en.wikipedia.org/wiki/Negation_as_failure
 ;;           https://en.wikipedia.org/wiki/Closed-world_assumption
@@ -58,6 +60,28 @@
      (if (empty? (qeval db negatee rules [frame]))
        [frame]
        []))
+   frames))
+
+(defn safe-ns-resolve
+  "Like ns-resolve but never returns `'clojure.core/eval`"
+  [ns sym]
+  (let [resolved (ns-resolve ns sym)]
+    (when (not= resolved #'clojure.core/eval)
+      resolved)))
+
+(defn apply-predicate
+  "Applies the `pred` to the `args` in the context of `frames`,
+  returning a seq of frames"
+  [_db pred args _rules frames]
+  (mapcat
+   (fn [frame]
+     (let [instantiated (binding/instantiate frame args (fn [v _f] v))
+           operator (or (safe-ns-resolve 'clojure.core pred)
+                        (match pred
+                          '!= not=))]
+       (if (apply operator instantiated)
+         [frame]
+         [])))
    frames))
 
 (defn cmp-fact-versions
@@ -208,18 +232,9 @@
              [:and & conjuncts] (conjoin db conjuncts rules frames)
              [:or & disjuncts] (disjoin db disjuncts rules frames)
              [:not negatee] (negate db negatee rules frames)
-          ;; TODO support lisp-value?
+             [([pred & args] :seq)] (apply-predicate db pred args rules frames)
              [:always-true] frames
              _ (simple-query db query rules frames))))
-
-;; A query is a map with the following structure:
-;;    {:find [?user ?tweet]
-;;     :where [[:likes ?user ?tweet]
-;;             (presidential ?tweet)]
-;;     :rules [[(presidential ?tweet)
-;;              [:author ?tweet ?author]
-;;              [:job ?author "president"]
-;;              (:not [:hand-size ?author "small"])]]}
 
 (defn pad-clause
   "Ensures the clause is a 5-tuple by padding it out with _s if necessary"
@@ -250,6 +265,7 @@
     [:and & conjuncts] `[:and ~@(map process-clause conjuncts)]
     [:or & disjuncts] `[:or ~@(map process-clause disjuncts)]
     [:not negatee] `[:not ~(process-clause negatee)]
+    [([op & args] :seq)] `[(~op ~@(map expand-question-marks args))]
     _ (-> clause (pad-clause) (expand-question-marks))))
 
 (defn process-where

--- a/src/unifydb/util.clj
+++ b/src/unifydb/util.clj
@@ -48,6 +48,4 @@
     (as-> results v
       (s/filter #(= (:id %) id) v)
       (s/take! v)
-      (d/chain v
-               #(assoc {} :results (:results %))
-               #(do (s/close! results) %)))))
+      (d/chain v #(do (s/close! results) %)))))

--- a/test/unifydb/query_test.clj
+++ b/test/unifydb/query_test.clj
@@ -1,8 +1,4 @@
 (ns unifydb.query-test
-  {:clj-kondo/config
-   '{:linters
-     {:unresolved-symbol
-      {:exclude [(unifydb.query-test/defquerytest)]}}}}
   (:require [clojure.test :refer [deftest is testing]]
             [unifydb.messagequeue.memory :as memqueue]
             [unifydb.query :as query]
@@ -11,150 +7,218 @@
             [unifydb.storage.memory :as memstore]
             [unifydb.util :as util]))
 
-(defmacro defquerytest [name [storage-backend queue-backend] facts & body]
-  `(deftest ~name
-     (let [facts# ~facts
-           ~storage-backend (store/transact-facts! (memstore/new) facts#)
-           ~queue-backend (memqueue/new)
-           query-service# (query/new ~queue-backend ~storage-backend)]
-       (try
-         (service/start! query-service#)
-         ~@body
-         (finally
-           (service/stop! query-service#))))))
-
-(defquerytest simple-matching [storage-backend queue-backend]
-  [[1 :name "Ben Bitdiddle" 0 true]
-   [1 :job [:computer :wizard] 0 true]
-   [1 :salary 60000 1 true]
-   [2 :name "Alyssa P. Hacker" 1 true]
-   [2 :job [:computer :programmer] 2 true]
-   [2 :salary 40000 2 true]
-   [2 :supervisor 1 2 true]
-   [1 :address [:slumerville [:ridge :road] 10] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 3 false]
-   [3 :address [:slumerville [:davis :square] 42] 4 true]]
-  (let [db-latest {:tx-id 4}
+(deftest simple-matching
+  (let [facts [[1 :name "Ben Bitdiddle" 0 true]
+               [1 :job [:computer :wizard] 0 true]
+               [1 :salary 60000 1 true]
+               [2 :name "Alyssa P. Hacker" 1 true]
+               [2 :job [:computer :programmer] 2 true]
+               [2 :salary 40000 2 true]
+               [2 :supervisor 1 2 true]
+               [1 :address [:slumerville [:ridge :road] 10] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 3 false]
+               [3 :address [:slumerville [:davis :square] 42] 4 true]]
+        storage-backend (store/transact-facts! (memstore/new) facts)
+        queue-backend (memqueue/new)
+        query-service (query/new queue-backend storage-backend)
+        db-latest {:tx-id 4}
         db-tx-2 {:tx-id 2}]
-    (doseq [{:keys [query db expected]}
-            [{:query '{:find [?e]
-                       :where [[?e :name "Ben Bitdiddle"]]}
-              :db db-latest
-              :expected '[[1]]}
-             {:query '{:find [?e ?what]
-                       :where [[?e :job [:computer ?what]]]}
-              :db db-latest
-              :expected '[[2 :programmer]
-                          [1 :wizard]]}
-             {:query '{:find [?town ?road-and-number]
-                       :where [[1 :address [?town & ?road-and-number]]]}
-              :db db-latest
-              :expected '[[:slumerville [[:ridge :road] 10]]]}
-             {:query '{:find [?town ?road-and-number]
-                       :where [[2 :address [?town & ?road-and-number]]]}
-              :db db-tx-2
-              :expected '[[:cambridge [[:mass :ave] 78]]]}
-             {:query '{:find [?town ?road-and-number]
-                       :where [[2 :address [?town & ?road-and-number]]]}
-              :db db-latest
-              :expected '[]}
-             {:query '{:find [?e]
-                       :where [[?e :job [:computer _]]]}
-              :db db-latest
-              :expected '[[2] [1]]}]]
-      (testing (str query)
-        (is (= (:results @(util/query queue-backend db query))
-               expected))))))
+    (try
+      (service/start! query-service)
+      (doseq [{:keys [query db expected]}
+              [{:query '{:find [?e]
+                         :where [[?e :name "Ben Bitdiddle"]]}
+                :db db-latest
+                :expected '[[1]]}
+               {:query '{:find [?e ?what]
+                         :where [[?e :job [:computer ?what]]]}
+                :db db-latest
+                :expected '[[2 :programmer]
+                            [1 :wizard]]}
+               {:query '{:find [?town ?road-and-number]
+                         :where [[1 :address [?town & ?road-and-number]]]}
+                :db db-latest
+                :expected '[[:slumerville [[:ridge :road] 10]]]}
+               {:query '{:find [?town ?road-and-number]
+                         :where [[2 :address [?town & ?road-and-number]]]}
+                :db db-tx-2
+                :expected '[[:cambridge [[:mass :ave] 78]]]}
+               {:query '{:find [?town ?road-and-number]
+                         :where [[2 :address [?town & ?road-and-number]]]}
+                :db db-latest
+                :expected '[]}
+               {:query '{:find [?e]
+                         :where [[?e :job [:computer _]]]}
+                :db db-latest
+                :expected '[[2] [1]]}]]
+        (testing (str query)
+          (is (= (:results @(util/query queue-backend db query))
+                 expected))))
+      (finally
+        (service/stop! query-service)))))
 
-(defquerytest compound-queries [storage-backend queue-backend]
-  [[1 :name "Ben Bitdiddle" 0 true]
-   [1 :job [:computer :wizard] 0 true]
-   [1 :salary 60000 1 true]
-   [2 :name "Alyssa P. Hacker" 1 true]
-   [2 :job [:computer :programmer] 2 true]
-   [2 :salary 40000 2 true]
-   [2 :supervisor 1 2 true]
-   [1 :address [:slumerville [:ridge :road] 10] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 3 false]
-   [3 :address [:slumerville [:davis :square] 42] 4 true]]
-  (let [db {:tx-id 4}]
-    (doseq [{:keys [query db expected]}
-            [{:query '{:find [?e ?what]
-                       :where [[:and
-                                [?e :job [:computer ?what]]
-                                [?e :salary 60000]]]}
-              :db db
-              :expected '[[1 :wizard]]}
-             {:query '{:find [?e ?what]
-                       :where [[?e :job [:computer ?what]]
-                               [?e :salary 60000]]}
-              :db db
-              :expected '[[1 :wizard]]}
-             {:query '{:find [?e]
-                       :where [[:or
-                                [?e :job [:computer :wizard]]
-                                [?e :job [:computer :programmer]]]]}
-              :db db
-              :expected '[[1] [2]]}
-             {:query '{:find [?e ?what]
-                       :where [[:and
-                                [?e :job [:computer ?what]]
-                                [:not [?e :salary 60000]]]]}
-              :db db
-              :expected '[[2 :programmer]]}]]
-      (testing (str query)
-        (is (= (:results @(util/query queue-backend db query))
-               expected))))))
+(deftest compound-queries
+  (let [facts [[1 :name "Ben Bitdiddle" 0 true]
+               [1 :job [:computer :wizard] 0 true]
+               [1 :salary 60000 1 true]
+               [2 :name "Alyssa P. Hacker" 1 true]
+               [2 :job [:computer :programmer] 2 true]
+               [2 :salary 40000 2 true]
+               [2 :supervisor 1 2 true]
+               [1 :address [:slumerville [:ridge :road] 10] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 3 false]
+               [3 :address [:slumerville [:davis :square] 42] 4 true]]
+        storage-backend (store/transact-facts! (memstore/new) facts)
+        queue-backend (memqueue/new)
+        query-service (query/new queue-backend storage-backend)
+        db {:tx-id 4}]
+    (try
+      (service/start! query-service)
+      (doseq [{:keys [query db expected]}
+              [{:query '{:find [?e ?what]
+                         :where [[:and
+                                  [?e :job [:computer ?what]]
+                                  [?e :salary 60000]]]}
+                :db db
+                :expected '[[1 :wizard]]}
+               {:query '{:find [?e ?what]
+                         :where [[?e :job [:computer ?what]]
+                                 [?e :salary 60000]]}
+                :db db
+                :expected '[[1 :wizard]]}
+               {:query '{:find [?e]
+                         :where [[:or
+                                  [?e :job [:computer :wizard]]
+                                  [?e :job [:computer :programmer]]]]}
+                :db db
+                :expected '[[1] [2]]}
+               {:query '{:find [?e ?what]
+                         :where [[:and
+                                  [?e :job [:computer ?what]]
+                                  [:not [?e :salary 60000]]]]}
+                :db db
+                :expected '[[2 :programmer]]}]]
+        (testing (str query)
+          (is (= (:results @(util/query queue-backend db query))
+                 expected))))
+      (finally
+        (service/stop! query-service)))))
 
-(defquerytest rules [storage-backend queue-backend]
-  [[1 :name "Ben Bitdiddle" 0 true]
-   [1 :job [:computer :wizard] 0 true]
-   [1 :salary 60000 1 true]
-   [2 :name "Alyssa P. Hacker" 1 true]
-   [2 :job [:computer :programmer] 2 true]
-   [2 :salary 40000 2 true]
-   [2 :supervisor 1 2 true]
-   [1 :address [:slumerville [:ridge :road] 10] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 2 true]
-   [2 :address [:cambridge [:mass :ave] 78] 3 false]
-   [3 :address [:slumerville [:davis :square] 42] 4 true]]
-  (let [db {:tx-id 4}]
-    (doseq [{:keys [query db expected]}
-            [{:query '{:find [?who]
-                       :where [(:lives-near ?who 1)]
-                       :rules [[(:lives-near ?person1 ?person2)
-                                [?person1 :address [?town & _]]
-                                [?person2 :address [?town & _]]
-                                [:not (:same ?person1 ?person2)]]
-                               [(:same ?x ?x)]]}
-              :db db
-              :expected '[[3]]}]]
-      (testing (str query)
-        (is (= (:results @(util/query queue-backend db query))
-               expected))))))
+(deftest rules
+  (let [facts [[1 :name "Ben Bitdiddle" 0 true]
+               [1 :job [:computer :wizard] 0 true]
+               [1 :salary 60000 1 true]
+               [2 :name "Alyssa P. Hacker" 1 true]
+               [2 :job [:computer :programmer] 2 true]
+               [2 :salary 40000 2 true]
+               [2 :supervisor 1 2 true]
+               [1 :address [:slumerville [:ridge :road] 10] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 3 false]
+               [3 :address [:slumerville [:davis :square] 42] 4 true]]
+        storage-backend (store/transact-facts! (memstore/new) facts)
+        queue-backend (memqueue/new)
+        query-service (query/new queue-backend storage-backend)
+        db {:tx-id 4}]
+    (try
+      (service/start! query-service)
+      (doseq [{:keys [query db expected]}
+              [{:query '{:find [?who]
+                         :where [(:lives-near ?who 1)]
+                         :rules [[(:lives-near ?person1 ?person2)
+                                  [?person1 :address [?town & _]]
+                                  [?person2 :address [?town & _]]
+                                  [:not (:same ?person1 ?person2)]]
+                                 [(:same ?x ?x)]]}
+                :db db
+                :expected '[[3]]}]]
+        (testing (str query)
+          (is (= (:results @(util/query queue-backend db query))
+                 expected))))
+      (finally
+        (service/stop! query-service)))))
 
-(defquerytest cardinality [storage-backend queue-backend]
-  [[1 :unifydb/schema :favorite-colors 0 true]
-   [1 :unifydb/cardinality :cardinality/many 0 true]
-   [2 :name "Bob" 0 true]
-   [2 :favorite-colors "red" 0 true]
-   [2 :favorite-colors "green" 0 true]
-   [2 :favorite-colors "blue" 0 true]
-   [2 :favorite-colors "blue" 1 false]
-   [3 :name "Emily" 2 true]
-   [3 :favorite-colors "yellow" 2 true]
-   [4 :name "Joe" 3 true]
-   [4 :lucky-number 7 3 true]
-   [4 :lucky-number 9 4 true]
-   [4 :lucky-number 9 5 false]]
-  (testing "Cardinality many"
-    (is (= [[2 "red"]
-            [2 "green"]
-            [3 "yellow"]]
-           (:results @(util/query queue-backend
-                                  {:tx-id 5}
-                                  '{:find [?ent ?color]
-                                    :where [[?ent :favorite-colors ?color]]})))))
-  (testing "Cardinality one double-assertion"))
+(deftest cardinality
+  (let [facts [[1 :unifydb/schema :favorite-colors 0 true]
+               [1 :unifydb/cardinality :cardinality/many 0 true]
+               [2 :name "Bob" 0 true]
+               [2 :favorite-colors "red" 0 true]
+               [2 :favorite-colors "green" 0 true]
+               [2 :favorite-colors "blue" 0 true]
+               [2 :favorite-colors "blue" 1 false]
+               [3 :name "Emily" 2 true]
+               [3 :favorite-colors "yellow" 2 true]
+               [4 :name "Joe" 3 true]
+               [4 :lucky-number 7 3 true]
+               [4 :lucky-number 9 4 true]
+               [4 :lucky-number 9 5 false]]
+        storage-backend (store/transact-facts! (memstore/new) facts)
+        queue-backend (memqueue/new)
+        query-service (query/new queue-backend storage-backend)]
+    (try
+      (service/start! query-service)
+      (testing "Cardinality many"
+        (is (= [[2 "red"]
+                [2 "green"]
+                [3 "yellow"]]
+               (:results @(util/query queue-backend
+                                      {:tx-id 5}
+                                      '{:find [?ent ?color]
+                                        :where [[?ent :favorite-colors ?color]]})))))
+      (finally
+        (service/stop! query-service)))))
+
+(deftest operators
+  (let [facts [[1 :name "Ben Bitdiddle" 0 true]
+               [1 :job [:computer :wizard] 0 true]
+               [1 :salary 60000 1 true]
+               [2 :name "Alyssa P. Hacker" 1 true]
+               [2 :job [:computer :programmer] 2 true]
+               [2 :salary 40000 2 true]
+               [2 :supervisor 1 2 true]
+               [1 :address [:slumerville [:ridge :road] 10] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 2 true]
+               [2 :address [:cambridge [:mass :ave] 78] 3 false]
+               [3 :address [:slumerville [:davis :square] 42] 4 true]]
+        storage-backend (store/transact-facts! (memstore/new) facts)
+        queue-backend (memqueue/new)
+        query-service (query/new queue-backend storage-backend)]
+    (try
+      (service/start! query-service)
+      (testing "Core functions"
+        (is (= [[2]]
+               (:results
+                @(util/query queue-backend
+                             {:tx-id 4}
+                             '{:find [?e]
+                               :where [[?e :salary ?s]
+                                       [?ben :name "Ben Bitdiddle"]
+                                       [?ben :salary ?bs]
+                                       [(< ?s ?bs)]]}))))
+        (is (= [[1]]
+               (:results
+                @(util/query queue-backend
+                             {:tx-id 4}
+                             '{:find [?e]
+                               :where [[?e :salary ?s]
+                                       [(< 50000 ?s 70000)]]}))))
+        (is (= [[2] [1]]
+               (:results
+                @(util/query queue-backend
+                             {:tx-id 4}
+                             '{:find [?e]
+                               :where [[?e :job ?job]
+                                       [(some #{:computer} ?job)]]}))))
+        (is (= [[2]]
+               (:results
+                @(util/query queue-backend
+                             {:tx-id 4}
+                             '{:find [?e]
+                               :where [[?e :job ?job]
+                                       [(some #{:computer} ?job)]
+                                       [?e :name ?name]
+                                       [(!= "Ben Bitdiddle" ?name)]]})))))
+      (finally
+        (service/stop! query-service)))))

--- a/test/unifydb/query_test.clj
+++ b/test/unifydb/query_test.clj
@@ -219,6 +219,26 @@
                                :where [[?e :job ?job]
                                        [(some #{:computer} ?job)]
                                        [?e :name ?name]
+                                       [(!= "Ben Bitdiddle" ?name)]]}))))
+        (is (= {:code :unbound-variable
+                :variable "joob"
+                :message "Unbound variable joob"}
+               (:error
+                @(util/query queue-backend
+                             {:tx-id 4}
+                             '{:find [?e]
+                               :where [[?e :job ?job]
+                                       [(some #{:computer} ?joob)]
+                                       [?e :name ?name]
                                        [(!= "Ben Bitdiddle" ?name)]]})))))
+      (is (= {:code :unknown-predicate
+              :predicate "foo"
+              :message "Unknown predicate foo"}
+             (:error
+              @(util/query queue-backend
+                           {:tx-id 4}
+                           '{:find [?e]
+                             :where [[?e :salary ?s]
+                                     [(foo 50000 ?s 70000)]]}))))
       (finally
         (service/stop! query-service)))))


### PR DESCRIPTION
This adds predicates to the query engine. Specifically, it exposes all of `clojure.core` except `eval` as callable filters in queries. Here's what it looks like:

``` clojure
{:find [?e]
 :where [[?e :salary ?s]
         [(> ?s 80000)]]}
```