### PR TITLE
Add support for querying :tx-id :latest

### DIFF
--- a/src/unifydb/storage.clj
+++ b/src/unifydb/storage.clj
@@ -1,12 +1,20 @@
-(ns unifydb.storage)
+(ns unifydb.storage
+  (:require [unifydb.binding :as bind]))
 
 (defprotocol IStorageBackend
   (transact-facts! [this facts]
     "Stores `facts` in `store`.")
-  (fetch-facts [this query tx-id frame]
+  (fetch-facts-internal [this query tx-id]
     "Retrieves the facts persisted as of the transaction
      denoted by `tx-id` that might unify with `query` from
      the `store` given the bindings in `frame`. Does not return
      facts that have been retracted.")
   (get-next-id [this]
     "Retrieves the next sequential id from the `store`."))
+
+(defn fetch-facts [store query tx-id frame]
+  (let [tx-id (if (= tx-id :latest)
+                Integer/MAX_VALUE
+                tx-id)
+        query (bind/instantiate frame query (fn [v _f] v))]
+    (fetch-facts-internal store query tx-id)))

--- a/src/unifydb/storage/memory.clj
+++ b/src/unifydb/storage/memory.clj
@@ -133,9 +133,8 @@
                (update s :avet
                        #(into % facts-avet)))))
     this)
-  (fetch-facts [this query tx-id frame]
-    (let [instantiated (binding/instantiate frame query (fn [v _f] v))]
-      (fetch-facts-from-index @(:state this) instantiated tx-id)))
+  (fetch-facts-internal [this query tx-id]
+    (fetch-facts-from-index @(:state this) query tx-id))
   (get-next-id [this]
     (:id-counter
      (swap! (:state this)

--- a/test/unifydb/storage/memory_test.clj
+++ b/test/unifydb/storage/memory_test.clj
@@ -1,5 +1,5 @@
 (ns unifydb.storage.memory-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [unifydb.storage.memory :as mem]
             [unifydb.storage :as store]))
 
@@ -69,6 +69,24 @@
               :tx-id 3
               :frame {}
               :expected [[2 :address [:cambridge [:mass :ave] 78] 2 true]
-                         [2 :address [:cambridge [:mass :ave] 78] 3 false]]}]]
-      (is (= (store/fetch-facts db query tx-id frame)
-             expected)))))
+                         [2 :address [:cambridge [:mass :ave] 78] 3 false]]}
+             {:query '[2 :address [? v]]
+              :tx-id :latest
+              :frame {}
+              :expected [[2 :address [:cambridge [:mass :ave] 78] 2 true]
+                         [2 :address [:cambridge [:mass :ave] 78] 3 false]]}
+             {:query '[[? e] [? a] [? v]]
+              :tx-id :latest
+              :frame {}
+              :expected [[1 :job [:computer :wizard] 0 true]          
+                         [1 :name "Ben Bitdiddle" 0 true]
+                         [1 :salary 60000 1 true]
+                         [2 :address [:cambridge [:mass :ave] 78] 2 true]
+                         [2 :address [:cambridge [:mass :ave] 78] 3 false]
+                         [2 :job [:computer :programmer] 2 true]
+                         [2 :name "Alyssa P. Hacker" 1 true]
+                         [2 :salary 40000 2 true]
+                         [2 :supervisor 1 2 true]]}]]
+      (testing {:query query :tx-id tx-id :frame frame}
+        (is (= expected
+               (store/fetch-facts db query tx-id frame)))))))


### PR DESCRIPTION
This adds the ability to query for `{:tx-id :latest}` instead of having to always specify a `tx-id`.