### PR TITLE
Add support for transacting entire entities as a map

### DIFF
--- a/test/unifydb/transact_test.clj
+++ b/test/unifydb/transact_test.clj
@@ -45,6 +45,74 @@
       (finally
         (service/stop! transact-service)))))
 
+(deftest transact-map-form-test
+  (let [queue-backend (memq/new)
+        transact-service (t/new queue-backend
+                                (storage/new!
+                                 (kvstore/new
+                                  (memstore/new))))]
+    (try
+      (service/start! transact-service)
+      (let [tx-data [{:unifydb/id "ben"
+                      :name "Ben Bitdiddle"
+                      :salary 60000}
+                     {:unifydb/id "alyssa"
+                      :name "Alyssa P. Hacker"
+                      :salary 40000
+                      :supervisor "ben"}]
+            tx-report (:tx-report @(t/transact queue-backend tx-data))
+            tempids (:tempids tx-report)
+            facts (:tx-data tx-report)
+            db-after (:db-after tx-report)]
+        (testing "Resolving temporary IDs"
+          (is (= ["ben" "alyssa" "unifydb.tx"] (keys tempids)))
+          (is (= (get tempids "ben") (fact-entity (first facts))))
+          (is (= (get tempids "alyssa") (fact-entity (nth facts 2))))
+          (is (= (fact-entity (first facts)) (fact-entity (second facts))))
+          (is (= (fact-entity (nth facts 2)) (fact-entity (nth facts 3))))
+          (is (= (fact-entity (nth facts 2)) (fact-entity (nth facts 4))))
+          (is (= (fact-entity (first facts)) (fact-value (nth facts 4)))))
+        (testing "Adding transaction metadata"
+          (is (= (fact-entity (last facts)) (get tempids "unifydb.tx")))
+          (is (= (fact-attribute (last facts)) :unifydb/txInstant))
+          (is (= java.lang.Long (type (fact-value (last facts)))))
+          (is (>= (System/currentTimeMillis) (fact-value (last facts)))))
+        (testing "Returning a new DB"
+          (is (= (get tempids "unifydb.tx") (:tx-id db-after)))))
+      (finally
+        (service/stop! transact-service)))))
+
+(deftest expand-map-forms-test
+  (let [test-cases [{:name "Basic example"
+                     :map-form {:unifydb/id "foo"
+                                :foo "bar"
+                                :baz "qux"}
+                     :add-forms [[:unifydb/add "foo" :foo "bar"]
+                                 [:unifydb/add "foo" :baz "qux"]]}
+                    {:name "Nested map"
+                     :map-form {:unifydb/id "foo"
+                                :bar {:unifydb/id "bar"
+                                      :baz "qux"}}
+                     :add-forms [[:unifydb/add "foo" :bar "bar"]
+                                 [:unifydb/add "bar" :baz "qux"]]}
+                    {:name "List value"
+                     :map-form {:unifydb/id "order1"
+                                :customer-id 1234
+                                :line-items [{:unifydb/id "li1" :cost 100}
+                                             {:unifydb/id "li2" :cost 200}]}
+                     :add-forms [[:unifydb/add "order1" :customer-id 1234]
+                                 [:unifydb/add "order1" :line-items "li1"]
+                                 [:unifydb/add "li1" :cost 100]
+                                 [:unifydb/add "order1" :line-items "li2"]
+                                 [:unifydb/add "li2" :cost 200]]}
+                    {:name "Non-map lists"
+                     :map-form {:unifydb/id "foo"
+                                :bar [1 2 3]}
+                     :add-forms [[:unifydb/add "foo" :bar [1 2 3]]]}]]
+    (doseq [{:keys [name map-form add-forms]} test-cases]
+      (testing name
+        (is (= (t/map-form->add-forms map-form) add-forms))))))
+
 (deftest transact-user-test
   (let [queue-backend (memq/new)
         store (storage/new! (kvstore/new (memstore/new)))


### PR DESCRIPTION
This makes it possible to transact entire entities as a map. For example, this transaction:

``` clojure
[{:unifydb/id "foo"
  :bar 14
  :baz {:unifydb/id "baz"
        :data 42}}]
```

Would get processed into the following set of `:unifydb/add` statements:

``` clojure
[[:unifydb/add "foo" :bar 14]
 [:unifydb/add "foo" :baz "baz"]
 [:unifydb/add "baz" :data 42]]
```

Notice that nested maps are processed as entity references. A list of maps will be treated the same way, but not lists that contain data other than maps.