### PR TITLE
Implement pull expressions

### DIFF
--- a/src/unifydb/binding.clj
+++ b/src/unifydb/binding.clj
@@ -1,6 +1,9 @@
 (ns unifydb.binding
-  (:refer-clojure :exclude [var?])
+  (:refer-clojure :exclude [var? var])
   (:require [unifydb.util :as util]))
+
+(defn var [name]
+  ['? (symbol name)])
 
 (defn var?
   "Checks if `exp` is a variable.

--- a/src/unifydb/query.clj
+++ b/src/unifydb/query.clj
@@ -445,6 +445,8 @@
   aggregation expressions in the `find` and the `sort-by`."
   [db find sort-by sort-direction limit frames]
   (let [grouping-vars (set (concat (filter var? find)
+                                   (map pull/pull-entity
+                                        (filter pull/pull-exp? find))
                                    (filter var? sort-by)))
         groupings (if (empty? grouping-vars)
                     ;; If there's nothing to group by, just have one big group

--- a/src/unifydb/query/pull.clj
+++ b/src/unifydb/query/pull.clj
@@ -1,0 +1,192 @@
+(ns unifydb.query.pull
+  (:require [clojure.string :as str]
+            [unifydb.binding :as bind]
+            [unifydb.id :refer [id?]]
+            [unifydb.util :as util :refer [deep-merge]]))
+
+(defn pull-exp? [exp]
+  (and (list? exp) (= (first exp) 'pull)))
+
+(defn pull-exp [entity query]
+  (list 'pull entity query))
+
+(defn pull-entity
+  "Extracts the entity part of a pull expression."
+  [pull-exp]
+  (second pull-exp))
+
+(defn pull-query
+  "Extracts the query part of a pull expression"
+  [pull-exp]
+  (nth pull-exp 2))
+
+;; ---------
+;; Overview of the strategy here:
+;; 1. Replace all instances of (pull) expressions in the parent query
+;;    with bindings that will return entity IDs
+;; 2. Execute the parent query. Now we have a list of entity ids to
+;;    pull for each pull expression
+;; 3. Transform the pull expressions into real queries and execute
+;;    them, constraining each pull query using the list of entity IDs
+;; 4. Collect the results and fill in the result of the parent query
+;;
+;; So we end up doing one subquery per pull expression in the parent
+;; query.
+
+(defn var-sym [id type]
+  (symbol (str "?" id "-" type)))
+
+(defn make-pull-query-accum
+  "Accumulator function to recursively build a pull query."
+  [acc depth current-id current-ent-var pull-exp id-gen]
+  (cond
+    (keyword? pull-exp) (assoc acc
+                               :where [current-ent-var
+                                       pull-exp
+                                       (var-sym current-id "val")]
+                               :depth (assoc (:depth acc)
+                                             current-id depth)
+                               :find (conj (:find acc)
+                                           (var-sym current-id "attr")
+                                           (var-sym current-id "val")))
+    (map? pull-exp) (let [attr (first (keys pull-exp))
+                          sub-exp (get pull-exp attr)
+                          new-ent-id (id-gen)
+                          new-depth (inc depth)
+                          subquery (make-pull-query-accum acc
+                                                          new-depth
+                                                          new-ent-id
+                                                          (var-sym current-id "val")
+                                                          sub-exp
+                                                          id-gen)]
+                      (assoc acc
+                             :where [:and
+                                     [current-ent-var
+                                      attr
+                                      (var-sym current-id "val")]
+                                     (:where subquery)]
+                             :find (concat (:find acc) (:find subquery))
+                             :depth (merge (:depth acc) (:depth subquery))))
+    (vector? pull-exp) (let [subqueries (map #(make-pull-query-accum acc
+                                                                     depth
+                                                                     current-id
+                                                                     current-ent-var
+                                                                     %
+                                                                     id-gen)
+                                             pull-exp)]
+                         (assoc acc
+                                :where `[:and
+                                         [:or
+                                          ~@(map :where subqueries)]
+                                         [~current-ent-var
+                                          ~(var-sym current-id "attr")
+                                          ~(var-sym current-id "val")]]
+                                :find (set (mapcat :find subqueries))
+                                :depth (apply merge (:depth acc) (map :depth subqueries))))))
+
+(defn make-pull-query
+  "Generates a pull query given the input pull expression and a list
+  of entity ids to pull."
+  ([pull-exp ids]
+   (make-pull-query pull-exp ids gensym))
+  ([pull-exp ids id-gen]
+   (let [ent-id (id-gen)
+         query-data (make-pull-query-accum {:depth {ent-id 0}
+                                            :find #{(var-sym ent-id "id")
+                                                    (var-sym ent-id "attr")
+                                                    (var-sym ent-id "val")}}
+                                           0
+                                           ent-id
+                                           (var-sym ent-id "id")
+                                           pull-exp
+                                           id-gen)]
+     {:depth (:depth query-data)
+      :query {:find (vec (:find query-data))
+              :where (into [(into [:or]
+                                  (map #(vector %
+                                                (var-sym ent-id "attr")
+                                                (var-sym ent-id "val"))
+                                       ids))]
+                           [(:where query-data)])}})))
+
+(defn parse-var
+  "Parses a pull variable into a name and a type, where type is one of
+  id, attr, or val."
+  [var]
+  (let [name (str (bind/var-name var))
+        last-dash-idx (str/last-index-of name "-")]
+    {:var-name (subs name 0 last-dash-idx)
+     :var-type (subs name (inc last-dash-idx))}))
+
+(defn parse-raw-pull-rows
+  "Given a set of raw rows from a pull query, parses the rows into a
+  nested map that matches the initial pull expression. Note that
+  cardinality-many attributes will be represented as maps keyed by
+  entity in the resulting map and will need to be further processed
+  into a list."
+  [raw-rows pull-find-clause depths]
+  (let [named-rows (map #(zipmap pull-find-clause %) raw-rows)
+        sorted-names (sort #(compare (depths %1) (depths %2)) (keys depths))
+        sorted-attrs (map #(bind/var (str % "-" "attr")) sorted-names)]
+    (reduce (fn [acc named-row]
+              (let [defined-attr-names (map (comp :var-name parse-var)
+                                            (filter (partial get named-row)
+                                                    sorted-attrs))
+                    defined-vars (concat
+                                  [(bind/var (str (first sorted-names)
+                                                  "-"
+                                                  "id"))]
+                                  (mapcat #(for [type ["attr" "val"]]
+                                             (bind/var (str % "-" type)))
+                                          defined-attr-names))
+                    vals (map (partial get named-row) defined-vars)
+                    row-map (assoc-in {} (butlast vals) (last vals))]
+                (deep-merge acc row-map)))
+            {}
+            named-rows)))
+
+(defn fix-cardinalities
+  "Given a map of parsed rows from a pull query, returns a map that is
+  a proper answer to the query with all nested entities as either
+  submaps or lists depending on cardinality."
+  [cardinalities parsed-rows]
+  (util/mapm (fn [attr val]
+               ;; TODO this opens up an edge case - if someone
+               ;; transacts a fact whose value is a map where all the
+               ;; keys are unifydb ids, this code will consider that
+               ;; map to be a sub-entity and parse it as such. Not
+               ;; sure the best way to handle this, but seems like a
+               ;; fairly unlikely edge case for now.
+               (if (and (map? val)
+                        (every? id? (keys val)))
+                 (if (= (get cardinalities attr) :cardinality/many)
+                   [attr (vec (map (partial fix-cardinalities cardinalities) (vals val)))]
+                   ;; TODO validate the assumption that we'll only
+                   ;; have 1 entity for cardinality one attributes in
+                   ;; the raw rows
+                   [attr (fix-cardinalities cardinalities (first (vals val)))])
+                 [attr val]))
+             parsed-rows))
+
+(defn parse-pull-rows
+  [raw-rows pull-find-clause depths cardinalities]
+  (let [rows (map (fn [row]
+                    (map (fn [exp]
+                           (if (bind/var? exp) nil exp))
+                         row))
+                  raw-rows)
+        parsed (parse-raw-pull-rows rows pull-find-clause depths)]
+    (util/mapm (fn [id entity]
+                 [id (fix-cardinalities cardinalities entity)])
+               parsed)))
+
+(defn pull-exp-attrs
+  "Returns all attributes present in the `pull-exp`."
+  [pull-exp]
+  (let [accum (fn accum [exp]
+                (cond
+                  (vector? exp) (into [] (mapcat accum exp))
+                  (map? exp) (into [(first (keys exp))]
+                                   (mapcat accum (first (vals exp))))
+                  (keyword? exp) [exp]))]
+    (vec (set (accum (pull-query pull-exp))))))

--- a/test/unifydb/pull_test.clj
+++ b/test/unifydb/pull_test.clj
@@ -1,0 +1,134 @@
+(ns unifydb.pull-test
+  (:require [clojure.test :refer [is deftest testing]]
+            [unifydb.query.pull :as pull]))
+
+(defn next-from [l]
+  (let [w (atom l)]
+    (fn []
+      (let [f (first @w)]
+        (when f (swap! w rest))
+        f))))
+
+(deftest test-make-pull-query
+  (doseq [{:keys [case pull-exp ids expected]}
+          [{:case "Nested pull expression"
+            :ids [#unifydb/id 1 #unifydb/id 2]
+            :pull-exp [:name
+                       :favorite-color
+                       {:status [:text]}
+                       {:friends [:name
+                                  :favorite-color
+                                  {:status [:text]}]}]
+            :expected '{:query
+                        {:find [?c-attr
+                                ?a-attr
+                                ?a-val
+                                ?c-val
+                                ?b-val
+                                ?d-val
+                                ?d-attr
+                                ?a-id
+                                ?b-attr]
+                         :where [[:or
+                                  [#unifydb/id 1 ?a-attr ?a-val]
+                                  [#unifydb/id 2 ?a-attr ?a-val]]
+                                 [:and
+                                  [:or
+                                   [?a-id :name ?a-val]
+                                   [?a-id :favorite-color ?a-val]
+                                   [:and
+                                    [?a-id :status ?a-val]
+                                    [:and
+                                     [:or
+                                      [?a-val :text ?b-val]]
+                                     [?a-val ?b-attr ?b-val]]]
+                                   [:and
+                                    [?a-id :friends ?a-val]
+                                    [:and
+                                     [:or
+                                      [?a-val :name ?c-val]
+                                      [?a-val :favorite-color ?c-val]
+                                      [:and
+                                       [?a-val :status ?c-val]
+                                       [:and
+                                        [:or
+                                         [?c-val :text ?d-val]]
+                                        [?c-val ?d-attr ?d-val]]]]
+                                     [?a-val ?c-attr ?c-val]]]]
+                                  [?a-id ?a-attr ?a-val]]]}
+                        :depth {"a" 0
+                                "b" 1
+                                "c" 1
+                                "d" 2}}}]]
+    (testing case
+      (is (= expected
+             (pull/make-pull-query pull-exp
+                                   ids
+                                   (next-from
+                                    ["a" "b" "c" "d" "e" "f" "g" "h" "i" "j"])))))))
+
+(deftest test-row-parsing
+  (let [raw-rows '[[#unifydb/id 2
+                    :name "Alice"
+                    nil nil
+                    nil nil
+                    nil nil]
+                   [#unifydb/id 2
+                    :favorite-color "red"
+                    nil nil
+                    nil nil
+                    nil nil]
+                   [#unifydb/id 2
+                    :status #unifydb/id 6
+                    :text "Feeling good"
+                    nil nil
+                    nil nil]
+                   [#unifydb/id 2
+                    :friends #unifydb/id 4
+                    nil nil
+                    :name "Carl"
+                    nil nil]
+                   [#unifydb/id 2
+                    :friends #unifydb/id 3
+                    nil nil
+                    :name "Bob"
+                    nil nil]
+                   [#unifydb/id 2
+                    :friends #unifydb/id 4
+                    nil nil
+                    :favorite-color "yellow"
+                    nil nil]
+                   [#unifydb/id 2
+                    :friends #unifydb/id 3
+                    nil nil
+                    :favorite-color "green"
+                    nil nil]
+                   [#unifydb/id 2
+                    :friends #unifydb/id 4
+                    nil nil
+                    :status #unifydb/id 7
+                    :text "Feeling bad"]]
+        find-clause '[[? a-id]
+                      [? a-attr]
+                      [? a-val]
+                      [? b-attr]
+                      [? b-val]
+                      [? c-attr]
+                      [? c-val]
+                      [? d-attr]
+                      [? d-val]]
+        depths '{"a" 0
+                 "b" 1
+                 "c" 1
+                 "d" 2}
+        cardinalities {:friends :cardinality/many}]
+    (is (= {#unifydb/id 2
+            {:name "Alice",
+             :favorite-color "red",
+             :status {:text "Feeling good"},
+             :friends
+             [{:name "Carl",
+               :favorite-color "yellow",
+               :status {:text "Feeling bad"}}
+              {:name "Bob", :favorite-color "green"}]}}
+           (pull/parse-pull-rows raw-rows find-clause depths cardinalities)))))

--- a/test/unifydb/query_test.clj
+++ b/test/unifydb/query_test.clj
@@ -554,7 +554,20 @@
                                         :favorite-color "yellow"
                                         :status {:text "Feeling bad"}}
                                        {:name "Bob"
-                                        :favorite-color "green"}]}]]}]]
+                                        :favorite-color "green"}]}]]}
+               {:db {:tx-id :latest}
+                :query '{:find [(pull ?e [:name])]
+                         :where [[?e :name _]]}
+                :expected [[{:name "Alice"}]
+                           [{:name "Bob"}]
+                           [{:name "Carl"}]]}
+               {:db {:tx-id :latest}
+                :query '{:find [(pull ?e [:name])
+                                (pull ?e [:favorite-color])]
+                         :where [[?e _ _]
+                                 [(= ?e #unifydb/id 2)]]}
+                :expected [[{:name "Alice"}
+                            {:favorite-color "red"}]]}]]
         (testing (str query)
           (if expected-error
             (is (= expected-error (:error @(util/query queue-backend db query))))


### PR DESCRIPTION
I don't love the name `pull`, but I don't have anything better at the moment. This is the query side of #15 - taken together, these features allow database users to transact entire entities and query entire entities from the database, allowing unifyDB to look and feel very much like a document store when that is convenient.